### PR TITLE
Add padding to all screens

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-08-16T02:58:39.071347Z">
+        <DropdownSelection timestamp="2025-08-16T13:44:34.268215Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/hyungwonjin/.android/avd/Pixel_9_Pro_API_35.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=2B081JEGR07640" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-08-16T13:44:34.268215Z">
+        <DropdownSelection timestamp="2025-08-16T14:00:49.905413Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=2B081JEGR07640" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/hyungwonjin/.android/avd/Pixel_9_Pro_API_35.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/example/ocr/screen/captured/CapturedScreen.kt
+++ b/app/src/main/java/com/example/ocr/screen/captured/CapturedScreen.kt
@@ -8,10 +8,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeContent
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -65,8 +68,11 @@ fun CapturedScreen(
           .fillMaxSize()
           .padding(padding),
       ) {
+        val safeContentPadding = WindowInsets.safeContent.asPaddingValues()
         Column(
-          modifier = Modifier.fillMaxSize(),
+          modifier = Modifier
+            .fillMaxSize()
+            .padding(safeContentPadding),
           verticalArrangement = Arrangement.SpaceBetween,
           horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt
+++ b/app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt
@@ -11,10 +11,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeGestures
 import androidx.compose.foundation.systemGestureExclusion
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -134,6 +137,7 @@ fun CropScreen(
         )
       },
     ) { innerPadding ->
+      val safeGestureInsets = WindowInsets.safeGestures.asPaddingValues()
 
       Surface(
         modifier = Modifier
@@ -172,6 +176,7 @@ fun CropScreen(
             ) {
               ImageCropper(
                 modifier = Modifier
+                  .padding(safeGestureInsets)
                   .fillMaxWidth()
                   .weight(1f)
                   // 2) This is the bounds of the cropper in the root layout

--- a/app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt
+++ b/app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt
@@ -192,6 +192,7 @@ fun CropScreen(
             SingleChoiceSegmentedButtonRow(
               modifier = Modifier
                 .fillMaxWidth()
+                .padding(horizontal = 24.dp),
             ) {
 
               SegmentedButton(

--- a/app/src/main/java/com/example/ocr/screen/draw/DrawScreen.kt
+++ b/app/src/main/java/com/example/ocr/screen/draw/DrawScreen.kt
@@ -14,9 +14,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeGestures
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -163,12 +166,15 @@ fun DrawScreen(
     Surface(
       modifier = Modifier.padding(it)
     ) {
+      val safeGestureInsets = WindowInsets.safeGestures.asPaddingValues()
+
       Column(
         Modifier
           .fillMaxSize()
       ) {
         Canvas(
           modifier = Modifier
+            .padding(safeGestureInsets)
             .weight(1f)
             .fillMaxSize()
             .onSizeChanged { size ->


### PR DESCRIPTION
This pull request improves the layout handling in several Compose screens by introducing support for safe area insets, ensuring that UI elements are correctly padded and do not overlap with system UI elements like notches or gesture bars. The changes affect the `CapturedScreen`, `CropScreen`, and `DrawScreen` components, enhancing their usability across devices with varying screen cutouts and gesture navigation.

**Safe area and gesture insets integration:**

* In `CapturedScreen.kt`, added use of `WindowInsets.safeContent` to apply safe content padding to the main `Column`, preventing content from being obscured by system UI elements. [[1]](diffhunk://#diff-b2c74edc4d98d8def37eab5a02e90aea52a4a249a92648dab795d5ae92d4850fR11-R17) [[2]](diffhunk://#diff-b2c74edc4d98d8def37eab5a02e90aea52a4a249a92648dab795d5ae92d4850fR71-R75)
* In `CropScreen.kt`, introduced `WindowInsets.safeGestures` to pad the `ImageCropper` and other UI elements, ensuring they remain accessible and unobstructed by gesture areas. Also added horizontal padding to the segmented button row for improved spacing. [[1]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aR14-R20) [[2]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aR140) [[3]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aR179) [[4]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aR195)
* In `DrawScreen.kt`, applied `WindowInsets.safeGestures` to the drawing canvas area, ensuring the drawing space is not impacted by gesture navigation zones. [[1]](diffhunk://#diff-ac5b1606cef43aa51539c1fd5d39064f2f7f889309a46f44df4eb34eb4e46e93R17-R22) [[2]](diffhunk://#diff-ac5b1606cef43aa51539c1fd5d39064f2f7f889309a46f44df4eb34eb4e46e93R169-R177)

**Project configuration:**

* Updated the device selection timestamp in `.idea/deploymentTargetSelector.xml` to reflect a new emulator session.