### PR TITLE
Add back navigation to Captured, Crop, and Draw screens

### DIFF
--- a/app/src/main/java/com/example/ocr/MainActivity.kt
+++ b/app/src/main/java/com/example/ocr/MainActivity.kt
@@ -64,6 +64,9 @@ class MainActivity : ComponentActivity() {
                 navController.navigate(
                   DrawRoute.create(capturedImageUri)
                 )
+              },
+              onBack = {
+                navController.popBackStack()
               }
             )
           }

--- a/app/src/main/java/com/example/ocr/screen/captured/CapturedScreen.kt
+++ b/app/src/main/java/com/example/ocr/screen/captured/CapturedScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -38,7 +40,8 @@ import com.example.ocr.ui.theme.OCRTheme
 fun CapturedScreen(
   capturedImageUri: Uri,
   onCrop: (Uri) -> Unit = {},
-  onDraw: (Uri) -> Unit = {}
+  onDraw: (Uri) -> Unit = {},
+  onBack: () -> Unit,
 ) {
   Box(
     modifier = Modifier
@@ -58,7 +61,15 @@ fun CapturedScreen(
         TopAppBar(
           title = {
             Text(text = "Preview Captured Image")
-          }
+          },
+          navigationIcon = {
+            IconButton(onClick = { onBack() }) {
+              Icon(
+                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                contentDescription = "Back"
+              )
+            }
+          },
         )
       }
     ) { padding ->
@@ -125,6 +136,6 @@ fun CapturedScreen(
 @Composable
 private fun CapturedScreenPreview() {
   OCRTheme {
-    CapturedScreen(capturedImageUri = Uri.EMPTY)
+    CapturedScreen(capturedImageUri = Uri.EMPTY, onBack = {})
   }
 }

--- a/app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt
+++ b/app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeGestures
 import androidx.compose.foundation.systemGestureExclusion
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -119,6 +120,14 @@ fun CropScreen(
       topBar = {
         TopAppBar(
           title = { Text("Crop") },
+          navigationIcon = {
+            IconButton(onClick = { openBackNavDialog.value = true }) {
+              Icon(
+                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                contentDescription = "Back"
+              )
+            }
+          },
           actions = {
             IconButton(
               onClick = {

--- a/app/src/main/java/com/example/ocr/screen/draw/DrawScreen.kt
+++ b/app/src/main/java/com/example/ocr/screen/draw/DrawScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.safeGestures
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -132,6 +133,14 @@ fun DrawScreen(
     topBar = {
       TopAppBar(
         title = { Text("Draw on Image") },
+        navigationIcon = {
+          IconButton(onClick = { openBackNavDialog.value = true }) {
+            Icon(
+              imageVector = Icons.AutoMirrored.Default.ArrowBack,
+              contentDescription = "Back"
+            )
+          }
+        },
         actions = {
           IconButton(
             onClick = {


### PR DESCRIPTION
This pull request introduces a consistent back navigation experience across the image preview, crop, and draw screens in the app. The main changes include adding back arrow icons to the top app bars and updating navigation logic to handle back actions properly.

**Navigation and UI consistency improvements:**

* Added a back arrow navigation icon to the top app bar in `CapturedScreen`, `CropScreen`, and `DrawScreen` using `Icons.AutoMirrored.Default.ArrowBack` for proper RTL/LTR support. (`app/src/main/java/com/example/ocr/screen/captured/CapturedScreen.kt` [[1]](diffhunk://#diff-b2c74edc4d98d8def37eab5a02e90aea52a4a249a92648dab795d5ae92d4850fR64-R72) [[2]](diffhunk://#diff-b2c74edc4d98d8def37eab5a02e90aea52a4a249a92648dab795d5ae92d4850fR18-R19); `app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt` [[3]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aR123-R130) [[4]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aR23); `app/src/main/java/com/example/ocr/screen/draw/DrawScreen.kt` [[5]](diffhunk://#diff-ac5b1606cef43aa51539c1fd5d39064f2f7f889309a46f44df4eb34eb4e46e93R136-R143) [[6]](diffhunk://#diff-ac5b1606cef43aa51539c1fd5d39064f2f7f889309a46f44df4eb34eb4e46e93R26)
* Modified the `CapturedScreen` composable to accept an `onBack` callback and updated its usage and preview accordingly. (`app/src/main/java/com/example/ocr/screen/captured/CapturedScreen.kt` [[1]](diffhunk://#diff-b2c74edc4d98d8def37eab5a02e90aea52a4a249a92648dab795d5ae92d4850fL41-R44) [[2]](diffhunk://#diff-b2c74edc4d98d8def37eab5a02e90aea52a4a249a92648dab795d5ae92d4850fL128-R139)
* Updated navigation logic in `MainActivity` to use `navController.popBackStack()` when the back action is triggered from the captured image preview. (`app/src/main/java/com/example/ocr/MainActivity.kt` [app/src/main/java/com/example/ocr/MainActivity.ktR67-R69](diffhunk://#diff-42516330e6e2ff92ad98efb4c1ef0731b1233cd0f711b6239d72b592b60fc71aR67-R69))

These changes ensure users can intuitively navigate back from image-related screens, improving the overall user experience and code maintainability.