### PR TITLE
Feature/add viewmodel on crop screen

### DIFF
--- a/app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt
+++ b/app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt
@@ -3,7 +3,6 @@
 package com.example.ocr.screen.crop
 
 import android.net.Uri
-import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,7 +16,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeGestures
-import androidx.compose.foundation.systemGestureExclusion
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
@@ -41,14 +39,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -58,6 +52,7 @@ import com.example.ocr.cropkit.CropDefaults
 import com.example.ocr.cropkit.CropShape
 import com.example.ocr.cropkit.ImageCropper
 import com.example.ocr.cropkit.rememberCropController
+import com.example.ocr.screen.crop.components.EdgeExclusionLayer
 import com.example.ocr.utils.saveTempBitmapToCache
 
 @Composable
@@ -275,107 +270,6 @@ fun CropScreen(
           }
         }
       }
-
     }
-  }
-}
-
-enum class Side { Left, Right }
-enum class Slot { Top, Middle, Bottom }
-
-@Composable
-fun EdgeExclusionLayer(
-  modifier: Modifier = Modifier,
-  targetBounds: Rect? = null,
-  content: @Composable () -> Unit,
-) {
-  if (targetBounds == null) {
-    content()
-    return
-  }
-  val density = LocalDensity.current
-
-  val makeRect: (LayoutCoordinates, Side, Slot) -> Rect = { coords, side, slot ->
-    sliceRectLocal(
-      coords = coords,
-      targetBounds = targetBounds,
-      density = density,
-      side = side,
-      slot = slot
-    )
-  }
-
-  val exclusionModifier =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-      Modifier
-        // The left side 3 slices
-        .systemGestureExclusion { coords -> makeRect(coords, Side.Left, Slot.Top) }
-        .systemGestureExclusion { coords -> makeRect(coords, Side.Left, Slot.Middle) }
-        .systemGestureExclusion { coords -> makeRect(coords, Side.Left, Slot.Bottom) }
-        // The right side 3 slices
-        .systemGestureExclusion { coords -> makeRect(coords, Side.Right, Slot.Top) }
-        .systemGestureExclusion { coords -> makeRect(coords, Side.Right, Slot.Middle) }
-        .systemGestureExclusion { coords -> makeRect(coords, Side.Right, Slot.Bottom) }
-    else Modifier
-
-  Box(
-    modifier
-      .fillMaxWidth()
-      .then(exclusionModifier)
-  ) {
-    content()
-  }
-}
-
-// The function creates 6 slices of Rects for the left and right sides of the cropper
-private fun sliceRectLocal(
-  coords: LayoutCoordinates,
-  targetBounds: Rect,
-  density: Density,
-  leftDp: Dp = 48.dp,
-  rightDp: Dp = 48.dp,
-  side: Side, // "left" or "right"
-  slot: Slot, // "top", "middle", or "bottom"
-): Rect {
-
-  val widthLocal = coords.size.width.toFloat()
-  val heightLocal = coords.size.height.toFloat()
-
-  // Take the top of this node (Box) in root coordinates and adjust it to local coordinates
-  val nodeTopInRoot = coords.boundsInRoot().top
-
-  // Adjust the target bounds to local coordinates
-  val topLocal = (targetBounds.top - nodeTopInRoot).coerceIn(0f, heightLocal)
-  val bottomLocal = (targetBounds.bottom - nodeTopInRoot).coerceIn(0f, heightLocal)
-  val targetH = (bottomLocal - topLocal).coerceAtLeast(0f)
-
-  // Convert Dp to pixels using the current density
-  val leftPx = with(density) { leftDp.toPx() }
-  val rightPx = with(density) { rightDp.toPx() }
-  val maxHPx = with(density) { 200.dp.toPx() }
-
-  val sliceH = (minOf(maxHPx, targetH)) / 3f
-  if (sliceH <= 0f) return Rect.Zero
-
-  val yTop = when (slot) {
-    Slot.Top -> topLocal - sliceH / 2f
-    Slot.Middle -> topLocal + (targetH - sliceH) / 2f
-    else -> bottomLocal - sliceH / 2f
-  }.coerceIn(0f, (heightLocal - sliceH).coerceAtLeast(0f))
-
-  return if (side == Side.Left) {
-    Rect(
-      left = 0f,
-      top = yTop,
-      right = leftPx.coerceAtMost(widthLocal),
-      bottom = (yTop + sliceH).coerceAtMost(heightLocal)
-    )
-  } else {
-    Rect(
-      left = (widthLocal - rightPx).coerceAtLeast(0f),
-      top = yTop,
-      right = widthLocal,
-      bottom = (yTop + sliceH).coerceAtMost(heightLocal)
-    )
   }
 }

--- a/app/src/main/java/com/example/ocr/screen/crop/CropUiState.kt
+++ b/app/src/main/java/com/example/ocr/screen/crop/CropUiState.kt
@@ -1,0 +1,13 @@
+package com.example.ocr.screen.crop
+
+import android.net.Uri
+import com.example.ocr.cropkit.CropShape
+import com.example.ocr.cropkit.GridLinesType
+
+data class CropUiState(
+  val sourceUri: Uri? = null,
+  val isLoading: Boolean = false,
+  val error: Throwable? = null,
+  val cropShape: CropShape = CropShape.FreeForm,
+  val gridLinesType: GridLinesType = GridLinesType.GRID,
+)

--- a/app/src/main/java/com/example/ocr/screen/crop/CropUiState.kt
+++ b/app/src/main/java/com/example/ocr/screen/crop/CropUiState.kt
@@ -8,6 +8,6 @@ data class CropUiState(
   val sourceUri: Uri? = null,
   val isLoading: Boolean = false,
   val error: Throwable? = null,
-  val cropShape: CropShape = CropShape.FreeForm,
-  val gridLinesType: GridLinesType = GridLinesType.GRID,
+  var cropShape: CropShape = CropShape.FreeForm,
+  var gridLinesType: GridLinesType = GridLinesType.GRID,
 )

--- a/app/src/main/java/com/example/ocr/screen/crop/CropViewModel.kt
+++ b/app/src/main/java/com/example/ocr/screen/crop/CropViewModel.kt
@@ -1,0 +1,42 @@
+package com.example.ocr.screen.crop
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.ocr.cropkit.CropShape
+import com.example.ocr.cropkit.GridLinesType
+import com.example.ocr.utils.loadBitmapFromUri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class CropViewModel() : ViewModel() {
+
+  private val _state = MutableStateFlow(CropUiState())
+  val state: StateFlow<CropUiState> = _state.asStateFlow()
+
+  private var decodedBitmap: Bitmap? = null
+
+  fun setSource(context: Context, uri: Uri) {
+    if (_state.value.sourceUri == uri) return
+    _state.update { it.copy(sourceUri = uri, isLoading = true, error = null) }
+    viewModelScope.launch(Dispatchers.IO) {
+      runCatching {
+        loadBitmapFromUri(context, uri)
+      }.onSuccess { bitmap ->
+        decodedBitmap = bitmap
+        _state.update { it.copy(isLoading = false) }
+      }.onFailure { error ->
+        _state.update { it.copy(isLoading = false, error = error) }
+      }
+    }
+  }
+
+  fun setCropShape(shape: CropShape) = _state.update { it.copy(cropShape = shape) }
+  fun setGridLinesType(type: GridLinesType) = _state.update { it.copy(gridLinesType = type) }
+}

--- a/app/src/main/java/com/example/ocr/screen/crop/CropViewModel.kt
+++ b/app/src/main/java/com/example/ocr/screen/crop/CropViewModel.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.ocr.cropkit.CropShape
-import com.example.ocr.cropkit.GridLinesType
 import com.example.ocr.utils.loadBitmapFromUri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,7 +19,8 @@ class CropViewModel() : ViewModel() {
   private val _state = MutableStateFlow(CropUiState())
   val state: StateFlow<CropUiState> = _state.asStateFlow()
 
-  private var decodedBitmap: Bitmap? = null
+  var decodedBitmap: Bitmap? = null
+    private set
 
   fun setSource(context: Context, uri: Uri) {
     if (_state.value.sourceUri == uri) return
@@ -38,5 +38,4 @@ class CropViewModel() : ViewModel() {
   }
 
   fun setCropShape(shape: CropShape) = _state.update { it.copy(cropShape = shape) }
-  fun setGridLinesType(type: GridLinesType) = _state.update { it.copy(gridLinesType = type) }
 }

--- a/app/src/main/java/com/example/ocr/screen/crop/components/EdgeExclusionLayer.kt
+++ b/app/src/main/java/com/example/ocr/screen/crop/components/EdgeExclusionLayer.kt
@@ -1,0 +1,115 @@
+package com.example.ocr.screen.crop.components
+
+import android.os.Build
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.systemGestureExclusion
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+enum class Side { Left, Right }
+enum class Slot { Top, Middle, Bottom }
+
+@Composable
+fun EdgeExclusionLayer(
+  modifier: Modifier = Modifier,
+  targetBounds: Rect? = null,
+  content: @Composable () -> Unit,
+) {
+  if (targetBounds == null) {
+    content()
+    return
+  }
+  val density = LocalDensity.current
+
+  val makeRect: (LayoutCoordinates, Side, Slot) -> Rect = { coords, side, slot ->
+    sliceRectLocal(
+      coords = coords,
+      targetBounds = targetBounds,
+      density = density,
+      side = side,
+      slot = slot
+    )
+  }
+
+  val exclusionModifier =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+      Modifier
+        // The left side 3 slices
+        .systemGestureExclusion { coords -> makeRect(coords, Side.Left, Slot.Top) }
+        .systemGestureExclusion { coords -> makeRect(coords, Side.Left, Slot.Middle) }
+        .systemGestureExclusion { coords -> makeRect(coords, Side.Left, Slot.Bottom) }
+        // The right side 3 slices
+        .systemGestureExclusion { coords -> makeRect(coords, Side.Right, Slot.Top) }
+        .systemGestureExclusion { coords -> makeRect(coords, Side.Right, Slot.Middle) }
+        .systemGestureExclusion { coords -> makeRect(coords, Side.Right, Slot.Bottom) }
+    else Modifier
+
+  Box(
+    modifier
+      .fillMaxWidth()
+      .then(exclusionModifier)
+  ) {
+    content()
+  }
+}
+
+// The function creates 6 slices of Rects for the left and right sides of the cropper
+private fun sliceRectLocal(
+  coords: LayoutCoordinates,
+  targetBounds: Rect,
+  density: Density,
+  leftDp: Dp = 48.dp,
+  rightDp: Dp = 48.dp,
+  side: Side, // "left" or "right"
+  slot: Slot, // "top", "middle", or "bottom"
+): Rect {
+
+  val widthLocal = coords.size.width.toFloat()
+  val heightLocal = coords.size.height.toFloat()
+
+  // Take the top of this node (Box) in root coordinates and adjust it to local coordinates
+  val nodeTopInRoot = coords.boundsInRoot().top
+
+  // Adjust the target bounds to local coordinates
+  val topLocal = (targetBounds.top - nodeTopInRoot).coerceIn(0f, heightLocal)
+  val bottomLocal = (targetBounds.bottom - nodeTopInRoot).coerceIn(0f, heightLocal)
+  val targetH = (bottomLocal - topLocal).coerceAtLeast(0f)
+
+  // Convert Dp to pixels using the current density
+  val leftPx = with(density) { leftDp.toPx() }
+  val rightPx = with(density) { rightDp.toPx() }
+  val maxHPx = with(density) { 200.dp.toPx() }
+
+  val sliceH = (minOf(maxHPx, targetH)) / 3f
+  if (sliceH <= 0f) return Rect.Zero
+
+  val yTop = when (slot) {
+    Slot.Top -> topLocal - sliceH / 2f
+    Slot.Middle -> topLocal + (targetH - sliceH) / 2f
+    else -> bottomLocal - sliceH / 2f
+  }.coerceIn(0f, (heightLocal - sliceH).coerceAtLeast(0f))
+
+  return if (side == Side.Left) {
+    Rect(
+      left = 0f,
+      top = yTop,
+      right = leftPx.coerceAtMost(widthLocal),
+      bottom = (yTop + sliceH).coerceAtMost(heightLocal)
+    )
+  } else {
+    Rect(
+      left = (widthLocal - rightPx).coerceAtLeast(0f),
+      top = yTop,
+      right = widthLocal,
+      bottom = (yTop + sliceH).coerceAtMost(heightLocal)
+    )
+  }
+}


### PR DESCRIPTION
This pull request refactors the crop screen to use a new `CropViewModel` and `CropUiState` for improved state management and code organization. The previous local state and coroutine logic in `CropScreen.kt` are migrated into the ViewModel, and the edge gesture exclusion logic is moved to its own file for better separation of concerns.

**State Management and Architecture:**

* Introduced `CropViewModel` and `CropUiState` to manage crop screen state, image loading, and crop options, moving logic out of the composable and into the ViewModel. (`app/src/main/java/com/example/ocr/screen/crop/CropViewModel.kt`, `app/src/main/java/com/example/ocr/screen/crop/CropUiState.kt`) [[1]](diffhunk://#diff-b62322e5abc858ea67a91d197cf096a7267a8fff20cb78f0d65d1e38cd409959R1-R41) [[2]](diffhunk://#diff-63c551c23f1c6a4c2357918c07b9460a6c51e3578265af0665140ff1d813b9dfR1-R13)
* Updated `CropScreen.kt` to use `viewModel.state` and `viewModel.decodedBitmap` instead of local state variables, and refactored crop shape/grid lines selection to use ViewModel methods. (`app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt`) [[1]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aR88-R104) [[2]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aL207-R198) [[3]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aL218-R209)

**Code Organization and Separation:**

* Moved the `EdgeExclusionLayer` composable and related logic to a dedicated file for improved modularity. (`app/src/main/java/com/example/ocr/screen/crop/components/EdgeExclusionLayer.kt`)
* Removed unused imports and code from `CropScreen.kt` related to the previous implementation of edge gesture exclusion and state management. (`app/src/main/java/com/example/ocr/screen/crop/CropScreen.kt`) [[1]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aL5-L7) [[2]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aL21) [[3]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aL45-R62) [[4]](diffhunk://#diff-31cb7ed11cf16ce1fcda5787d11c2c77d56080ece04bb762ffd631fe7983298aL283-L384)

These changes make the crop screen more maintainable, testable, and consistent with recommended Android architecture patterns.